### PR TITLE
Cadatan/dockerize

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  client:
+    image: node:alpine
+    volumes:
+      - ./client:/client
+    working_dir: /client
+    command: sh -c "npm install && sleep infinity"
+    tty: true
+  
+  server:
+    image: node:alpine
+    volumes:
+      - ./server:/server
+    working_dir: /server
+    command: sh -c "npm install && sleep infinity"
+    tty: true

--- a/server/src/handlers/CimaEventHandler.ts
+++ b/server/src/handlers/CimaEventHandler.ts
@@ -6,7 +6,7 @@ import {
     GetAllEvents,
     GetEvent,
     UpdateEvent,
-} from "../controllers/cimaeventController";
+} from "../controllers/CimaEventController";
 
 export async function getAllEvents(req: Request, res: Response) {
     try {


### PR DESCRIPTION
Created a docker-compose file. You can now run the server and app in separate containers. We could all have the same dev environment, so no more "Idk it works on my machine" or "Did you install nvm?" conversations. This is extra useful if you're using WSL2 btw ;)

The command to build/rebuild the containers:  
> docker-compose up -d
> docker-compose down

After the containers are up, you can use the Remote Development extension on vscode to attach to the containers. 
